### PR TITLE
Normalize multiple client IPs in case of proxy request

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -278,7 +278,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     public function getClientIp()
     {
-        return $this->_request->getClientIp();
+        $clientIp = $this->_request->getClientIp();
+        if(strpos($clientIp, ',') !== false) {
+            // more than one ip given (due to proxy) -> normalize ip
+            list($firstIp,) = explode(',', (string)$clientIp, 2);
+            $clientIp = trim($firstIp);
+        }
+        return $clientIp;
     }
 
     /**


### PR DESCRIPTION
In some cases proxy server might add more than one IP to the X-Forwareded-For header so the central IP validation will fail and might cause additional issues later when processing.
So I added an normalization step that makes sure only one the original (first) IP is returned.
In our case this works very well.
