### PR TITLE
Please update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "magento/module-sales": "*",
         "magento/module-payment": "*",
         "magento/module-quote": "*",
-        "wirecard/checkout-client-library": "3.3.0"
+        "wirecard/checkout-client-library": "3.3.*"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
In order to get wirecard/magento2-wcp to be installed on a PHP 7 platform I had to install wirecard/checkout-client-library. Version 3.3.0 is not PHP 7 compatible, while 3.3.1 is. Hope it's OK for you to require 3.3.* instead of 3.3.0