### PR TITLE
Treat ReservedOrderId as String

### DIFF
--- a/Model/AbstractPayment.php
+++ b/Model/AbstractPayment.php
@@ -146,7 +146,7 @@ abstract class AbstractPayment extends AbstractMethod
         $quote->save();
 
         $orderId = $quote->getReservedOrderId();
-        $init->setOrderReference(sprintf('%010d', $orderId));
+        $init->setOrderReference(sprintf('%s', $orderId));
         $init->uniqueId = $this->_getUniqueId($cart);
 
         $init->setAmount(round($cart->getQuote()->getBaseGrandTotal(), $this->_dataHelper->getPrecision()))
@@ -166,7 +166,7 @@ abstract class AbstractPayment extends AbstractMethod
         $init->mage_quoteId       = $quote->getId();
         $init->mage_orderCreation = $this->_dataHelper->getConfigData('options/order_creation');
 
-        $init->generateCustomerStatement($this->_dataHelper->getConfigData('options/shopname'), sprintf('%010d', $orderId));
+        $init->generateCustomerStatement($this->_dataHelper->getConfigData('options/shopname'), sprintf('%s', $orderId));
 
         if ($this->_dataHelper->getConfigData('options/sendbasketinformation') || $this->forceSendingBasket()) {
             $basket = new \WirecardCEE_Stdlib_Basket();


### PR DESCRIPTION
the Magento reserved_order_id field is not to be treated as a numeric field.
It should be treated as a string because it can contain characters.

By using `sprintf('%010d', $orderId)` the reserved_order_id will be treated incorrectly.
The Magento reserved_order_id field does not contain an actual integer value.
Moreover it cotains the order_increment_id which is the human readable order reference send to the customer.
Magento allows this increment_id to have Characters so an increment_id like this `ORDER-10000005` is totally possible.

