### PR TITLE
#46 Prevent duplicate order confirmation emails

### DIFF
--- a/Model/OrderManagement.php
+++ b/Model/OrderManagement.php
@@ -48,11 +48,6 @@ class OrderManagement
     protected $_transactionBuilder;
 
     /**
-     * @var \Magento\Sales\Model\Order\Email\Sender\OrderSender;
-     */
-    protected $_orderSender;
-
-    /**
      * @var \Magento\Sales\Model\Order\Payment\Transaction\Repository
      */
     protected $_transactionRepository;
@@ -88,7 +83,6 @@ class OrderManagement
         \Psr\Log\LoggerInterface $logger,
         \Wirecard\CheckoutPage\Helper\Data $helper,
         \Magento\Sales\Model\Order\Payment\Transaction\BuilderInterface $transactionBuilder,
-        \Magento\Sales\Model\Order\Email\Sender\OrderSender $orderSender,
         \Magento\Sales\Api\TransactionRepositoryInterface $transactionRepository,
         \Magento\Quote\Api\CartManagementInterface $quoteManagement,
         \Magento\Quote\Api\CartRepositoryInterface $quoteRepository,
@@ -97,7 +91,6 @@ class OrderManagement
         $this->_logger                = $logger;
         $this->_dataHelper            = $helper;
         $this->_transactionRepository = $transactionRepository;
-        $this->_orderSender           = $orderSender;
         $this->_transactionBuilder    = $transactionBuilder;
         $this->_quoteManagement       = $quoteManagement;
         $this->_objectManager         = $objectManager;
@@ -387,8 +380,6 @@ class OrderManagement
 
                     $order->addRelatedObject($invoice);
                 }
-
-                $this->_orderSender->send($order);
             }
 
             $type = $doCapture ? Transaction::TYPE_CAPTURE : Transaction::TYPE_AUTH;


### PR DESCRIPTION
Email sending by order management class is not required any more, since the order status is correctly set and email is sent by Magento core functions.